### PR TITLE
[Bug fix] violation detection is now properly disabled in SimProcedures

### DIFF
--- a/guardian/breakpoints.py
+++ b/guardian/breakpoints.py
@@ -26,21 +26,22 @@ log = logging.getLogger(__name__)
 
 
 class Breakpoints:
-    def setup(self, proj, simgr, layout):
+    def setup(self, proj, simgr, layout, violation_check=True):
 
         # Violation detection breakpoints
-        simgr.active[0].inspect.b(
-            'mem_read',
-            when=angr.BP_BEFORE,
-            action=lambda s: self.detect_read_violations(simgr, s, layout))
-        simgr.active[0].inspect.b(
-            'mem_write',
-            when=angr.BP_BEFORE,
-            action=lambda s: self.detect_write_violations(simgr, s, layout))
-        simgr.active[0].inspect.b(
-            'exit',
-            when=angr.BP_BEFORE,
-            action=lambda s: self.detect_jump_violations(simgr, s, layout))
+        if violation_check:
+            simgr.active[0].inspect.b(
+                'mem_read',
+                when=angr.BP_BEFORE,
+                action=lambda s: self.detect_read_violations(simgr, s, layout))
+            simgr.active[0].inspect.b(
+                'mem_write',
+                when=angr.BP_BEFORE,
+                action=lambda s: self.detect_write_violations(simgr, s, layout))
+            simgr.active[0].inspect.b(
+                'exit',
+                when=angr.BP_BEFORE,
+                action=lambda s: self.detect_jump_violations(simgr, s, layout))
 
         # Call stack tracking breakpoints
         simgr.active[0].inspect.b(

--- a/guardian/hooker.py
+++ b/guardian/hooker.py
@@ -81,7 +81,7 @@ class Hooker:
     def instruction_replacement(self, exit_addr):
         def replace(capstone_instruction) -> angr.SimProcedure:
             if capstone_instruction.mnemonic == "enclu" and capstone_instruction.address != exit_addr:
-                return SimEnclu()
+                return SimEnclu(violation_check=True)
             elif capstone_instruction.mnemonic == "xsave64":
                 return Nop(bytes_to_skip=4)
             elif capstone_instruction.mnemonic == "xrstor64":

--- a/guardian/project.py
+++ b/guardian/project.py
@@ -78,13 +78,12 @@ class Project:
                 "df", self.entry_state.arch.bits)
 
         self.simgr = self.angr_project.factory.simgr(self.entry_state)
-        self.angr_project, self.simgr = Hooker().setup(
+        self.angr_project, self.simgr = Hooker(violation_check).setup(
             self.angr_project, self.simgr, self.ecalls, self.ocalls,
             self.exit_addr, self.enter_addr, self.old_sdk)
         # Enable violation checks if flag is set
-        if violation_check:
-            self.angr_project, self.simgr = Breakpoints().setup(
-                self.angr_project, self.simgr, self.layout)
+        self.angr_project, self.simgr = Breakpoints().setup(
+            self.angr_project, self.simgr, self.layout, violation_check = violation_check)
         self.simgr.use_technique(EnclaveExploration())
 
     def use_heurestic_for_ecalls_or_ocalls(self):

--- a/guardian/project.py
+++ b/guardian/project.py
@@ -100,6 +100,10 @@ class Project:
 
     def init_enclave_state(self):
         self.entry_state = self.angr_project.factory.blank_state()
+        # Set angr options to silence warnings
+        self.entry_state.options.add(angr.options.SYMBOL_FILL_UNCONSTRAINED_MEMORY)
+        self.entry_state.options.add(angr.options.SYMBOL_FILL_UNCONSTRAINED_REGISTERS)
+        # Setup entry state
         self.entry_state.regs.rip = self.angr_project.loader.find_symbol(
             "enclave_entry").rebased_addr
         self.entry_state.regs.rax = 0x0

--- a/guardian/simulation_procedures.py
+++ b/guardian/simulation_procedures.py
@@ -24,7 +24,15 @@ import collections
 log = logging.getLogger(__name__)
 
 
-class SimEnclu(angr.SimProcedure):
+class GuardianSimProcedure(angr.SimProcedure):
+    """Base class for all Guardian SimProcedures. This class provides a common interface for all Guardian SimProcedures."""
+    def __init__(self, violation_check=True, **kwargs):
+        """Initialise the SimProcedure. If violation_check is True, then violations are checked."""
+        super().__init__(**kwargs)
+        self.violation_check = violation_check
+
+
+class SimEnclu(GuardianSimProcedure):
     IS_FUNCTION = False
 
     def run(self):
@@ -50,7 +58,8 @@ class SimEnclu(angr.SimProcedure):
             self.exit(1)
 
 
-class Nop(angr.SimProcedure):
+class Nop(GuardianSimProcedure):
+
     IS_FUNCTION = False
 
     def run(self, **kwargs):
@@ -59,12 +68,13 @@ class Nop(angr.SimProcedure):
             self.state.solver.true, 'Ijk_Boring')
 
 
-class Empty(angr.SimProcedure):
+class Empty(GuardianSimProcedure):
+
     def run(self):
         pass
 
 
-class UD2(angr.SimProcedure):
+class UD2(GuardianSimProcedure):
     IS_FUNCTION = False
 
     def run(self, **kwargs):
@@ -75,7 +85,7 @@ class UD2(angr.SimProcedure):
         self.exit(2)
 
 
-class Rdrand(angr.SimProcedure):
+class Rdrand(GuardianSimProcedure):
     IS_FUNCTION = False
 
     def run(self, **kwargs):
@@ -84,7 +94,7 @@ class Rdrand(angr.SimProcedure):
                                       self.state.solver.true, 'Ijk_Boring')
 
 
-class RegisterEnteringValidation(angr.SimProcedure):
+class RegisterEnteringValidation(GuardianSimProcedure):
     IS_FUNCTION = False
 
     def run(self, **kwargs):
@@ -109,7 +119,7 @@ class RegisterEnteringValidation(angr.SimProcedure):
                                       self.state.solver.true, 'Ijk_NoHook')
 
 
-class TransitionToTrusted(angr.SimProcedure):
+class TransitionToTrusted(GuardianSimProcedure):
     IS_FUNCTION = False
 
     def run(self, **kwargs):
@@ -136,7 +146,7 @@ class TransitionToTrusted(angr.SimProcedure):
                                       self.state.solver.true, 'Ijk_NoHook')
 
 
-class TransitionToExiting(angr.SimProcedure):
+class TransitionToExiting(GuardianSimProcedure):
     IS_FUNCTION = False
 
     def run(self, **kwargs):
@@ -156,7 +166,7 @@ class TransitionToExiting(angr.SimProcedure):
                                       self.state.solver.true, 'Ijk_NoHook')
 
 
-class TransitionToExited(angr.SimProcedure):
+class TransitionToExited(GuardianSimProcedure):
     IS_FUNCTION = False
 
     def run(self, **kwargs):
@@ -182,7 +192,7 @@ class TransitionToExited(angr.SimProcedure):
                                       self.state.solver.true, 'Ijk_NoHook')
 
 
-class TransitionToOcall(angr.SimProcedure):
+class TransitionToOcall(GuardianSimProcedure):
     IS_FUNCTION = False
 
     def run(self, **kwargs):
@@ -202,7 +212,7 @@ class TransitionToOcall(angr.SimProcedure):
                                       self.state.solver.true, 'Ijk_NoHook')
 
 
-class OcallAbstraction(angr.SimProcedure):
+class OcallAbstraction(GuardianSimProcedure):
     def run(self, **kwargs):
         log.debug("######### OCALL ABSTRACTION ###############")
         assert self.state.has_plugin("enclave")
@@ -216,7 +226,7 @@ class OcallAbstraction(angr.SimProcedure):
                                                self.state.arch.bits)
 
 
-class malloc(angr.SimProcedure):
+class malloc(GuardianSimProcedure):
     def run(self, sim_size):
         if self.state.solver.symbolic(sim_size):
             log.warning("Allocating size {}\n".format(sim_size))

--- a/guardian/simulation_procedures.py
+++ b/guardian/simulation_procedures.py
@@ -100,20 +100,21 @@ class RegisterEnteringValidation(GuardianSimProcedure):
     def run(self, **kwargs):
         log.debug("######### REGISTER ENTERING VALIDATION ###############")
         assert self.state.has_plugin("enclave")
-        if self.state.enclave.control_state != ControlState.Entering:
-            violation = (ViolationType.Transition,
-                         ViolationType.Transition.to_msg(),
-                         self.state.enclave.control_state,
-                         "EnteringSanitisation")
-            self.state.enclave.set_violation(violation)
-            self.state.enclave.found_violation = True
-        else:
-            assert "no_sanitisation" in kwargs
-            if not kwargs["no_sanitisation"]:
-                violation = Validation.entering(self.state)
-                if violation is not None:
-                    self.state.enclave.set_violation(violation)
-                    self.state.enclave.found_violation = True
+        if self.violation_check:
+            if self.state.enclave.control_state != ControlState.Entering:
+                violation = (ViolationType.Transition,
+                            ViolationType.Transition.to_msg(),
+                            self.state.enclave.control_state,
+                            "EnteringSanitisation")
+                self.state.enclave.set_violation(violation)
+                self.state.enclave.found_violation = True
+            else:
+                assert "no_sanitisation" in kwargs
+                if not kwargs["no_sanitisation"]:
+                    violation = Validation.entering(self.state)
+                    if violation is not None:
+                        self.state.enclave.set_violation(violation)
+                        self.state.enclave.found_violation = True
         self.state.enclave.entry_sanitisation_complete = True
         self.successors.add_successor(self.state, self.state.addr + 0,
                                       self.state.solver.true, 'Ijk_NoHook')
@@ -125,7 +126,7 @@ class TransitionToTrusted(GuardianSimProcedure):
     def run(self, **kwargs):
         log.debug("######### TRUSTED ###############")
         assert self.state.has_plugin("enclave")
-        if not (self.state.enclave.control_state == ControlState.Entering
+        if self.violation_check and not (self.state.enclave.control_state == ControlState.Entering
                 or self.state.enclave.control_state == ControlState.Ocall):
             violation = (ViolationType.Transition,
                          ViolationType.Transition.to_msg(),
@@ -133,7 +134,7 @@ class TransitionToTrusted(GuardianSimProcedure):
                          ControlState.Trusted)
             self.state.enclave.set_violation(violation)
             self.state.enclave.found_violation = True
-        elif not self.state.enclave.entry_sanitisation_complete:
+        elif self.violation_check and not self.state.enclave.entry_sanitisation_complete:
             violation = (ViolationType.Transition,
                          ViolationType.Transition.to_msg(),
                          "Entering Trusted without entry sanitisation")
@@ -152,7 +153,7 @@ class TransitionToExiting(GuardianSimProcedure):
     def run(self, **kwargs):
         log.debug("######### EXITING ###############")
         assert self.state.has_plugin("enclave")
-        if self.state.enclave.control_state != ControlState.Trusted:
+        if self.violation_check and self.state.enclave.control_state != ControlState.Trusted:
             violation = (ViolationType.Transition,
                          ViolationType.Transition.to_msg(),
                          self.state.enclave.control_state,
@@ -172,7 +173,7 @@ class TransitionToExited(GuardianSimProcedure):
     def run(self, **kwargs):
         log.debug("######### EXITED ###############")
         assert self.state.has_plugin("enclave")
-        if not (self.state.enclave.control_state == ControlState.Exiting
+        if self.violation_check and not (self.state.enclave.control_state == ControlState.Exiting
                 or self.state.enclave.control_state == ControlState.Entering):
             violation = (ViolationType.Transition,
                          ViolationType.Transition.to_msg(),
@@ -180,7 +181,7 @@ class TransitionToExited(GuardianSimProcedure):
             self.state.enclave.set_violation(violation)
             self.state.enclave.found_violation = True
         else:
-            if self.state.enclave.control_state == ControlState.Exiting:
+            if self.violation_check and self.state.enclave.control_state == ControlState.Exiting:
                 assert "no_sanitisation" in kwargs
                 if not kwargs["no_sanitisation"]:
                     violation = Validation.exited(self.state)
@@ -199,7 +200,7 @@ class TransitionToOcall(GuardianSimProcedure):
         log.debug("######### OCALL ###############")
         log.debug(hex(self.state.addr))
         assert self.state.has_plugin("enclave")
-        if self.state.enclave.control_state != ControlState.Trusted:
+        if self.violation_check and self.state.enclave.control_state != ControlState.Trusted:
             violation = (ViolationType.Transition,
                          ViolationType.Transition.to_msg(),
                          self.state.enclave.control_state, ControlState.Ocall)
@@ -216,7 +217,7 @@ class OcallAbstraction(GuardianSimProcedure):
     def run(self, **kwargs):
         log.debug("######### OCALL ABSTRACTION ###############")
         assert self.state.has_plugin("enclave")
-        if self.state.enclave.control_state != ControlState.Ocall:
+        if self.violation_check and self.state.enclave.control_state != ControlState.Ocall:
             violation = (ViolationType.Transition,
                          ViolationType.Transition.to_msg(),
                          self.state.enclave.control_state, "OcallAbstraction")

--- a/tests/test_disable_violation_check.py
+++ b/tests/test_disable_violation_check.py
@@ -1,23 +1,39 @@
+""" Guardian
+    Copyright (C) 2021  The Blockhouse Technology Limited (TBTL)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>."""
+
 import angr
-import claripy
-# guardian
-import guardian 
-# pytest
+import guardian
 import pytest
-# Pathlib for path manipulation
 import pathlib
 
+FILE_DIR = pathlib.Path(__file__).parent
+
 class Project:
-    def setup(self,
-              path,
-              heap_size=None,
-              stack_size=None,
-              ecalls=None,
-              ocalls=None,
-              exit_addr=None,
-              enter_addr=None,
-              target_ecall=0x0,
-              violation_check=False):
+    """A class to setup a project and simulation manager for testing."""
+
+    def setup(
+        self,
+        path,
+        heap_size=None,
+        stack_size=None,
+        ecalls=None,
+        ocalls=None,
+        exit_addr=None,
+        enter_addr=None,
+    ):
         self.path = path
         self.proj = angr.Project(self.path)
         self.heap_size = heap_size
@@ -27,36 +43,106 @@ class Project:
         self.exit_addr = exit_addr
         self.enter_addr = enter_addr
         self.guardian_proj = guardian.Project(
-            self.proj, self.heap_size, self.stack_size, self.ecalls,
-            self.ocalls, self.exit_addr, self.enter_addr, violation_check=violation_check)
-        self.guardian_proj.set_target_ecall(target_ecall)
+            self.proj,
+            self.heap_size,
+            self.stack_size,
+            self.ecalls,
+            self.ocalls,
+            self.exit_addr,
+            self.enter_addr,
+            violation_check=False, # Disable violation check
+        )
+        
+        self.guardian_proj.set_target_ecall(0x0)
         self.simgr = self.guardian_proj.simgr
         return self.proj, self.simgr
 
 
-# Before fix
 @pytest.fixture
 def setup():
     return Project().setup
 
 
-def test_disable_violation_check(setup):
-    """Test that violation detection can be disabled"""
-    # guardian configuration
-    enclave_path = pathlib.Path(__file__).parent / "disable_violation_check"/ "enclave.signed.so"
-    ecalls = [(1, 'sgx_e_mpz_add', 4200800,
-            [(4201309, 4201314), (4201351, 4201356),
-                (4201459,
-                4201464)])]  # can be found manually or by calling heuristics
-    find_missing_ecalls_or_ocalls = False  # tell angr not to look for missing ocalls (ecalls we supplied)
-    proj, simgr = setup(enclave_path, ecalls=ecalls, target_ecall=0x1, violation_check=False)
-
-    # Test that we can still reach the target ecall (Meaning the setup worked)
-    simgr.explore(find=proj.loader.find_symbol('sgx_e_mpz_add').rebased_addr)
-    assert simgr.found, "Could not reach target ecall"
-
-    # Test that exploration still works and violation detection is disabled
-    simgr.move(from_stash='found', to_stash='active')
+def test_all_violations(setup):
+    proj, simgr = setup(FILE_DIR/"all_violations"/"enclave.so")
     simgr.explore()
-    assert not simgr.violation, "Violation found when detection is disabled"
 
+    assert len(simgr.violation) == 0
+
+
+def test_entry_sanitisation(setup):
+    proj, simgr = setup(FILE_DIR /"entry_sanitisation"/"enclave.so")
+    proj.hook(0x40685E, hook=guardian.simulation_procedures.Nop(bytes_to_skip=31))
+    proj.hook(0x4068AC, hook=guardian.simulation_procedures.Nop(bytes_to_skip=18))
+    simgr.explore()
+
+    assert len(simgr.violation) == 0
+
+
+def test_exit_sanitisation(setup):
+    proj, simgr = setup(FILE_DIR/"exit_sanitisation"/"enclave.so")
+    proj.hook(0x406924, hook=guardian.simulation_procedures.Nop(bytes_to_skip=34))
+    simgr.explore()
+
+    assert len(simgr.violation) == 0
+
+
+def test_good_case(setup):
+    proj, simgr = setup(FILE_DIR/"good_case"/"enclave.so")
+    simgr.explore()
+
+    assert len(simgr.violation) == 0
+
+
+def test_out_of_jump(setup):
+    proj, simgr = setup(FILE_DIR/"out_of_jump"/"enclave.so")
+    simgr.explore()
+
+    assert len(simgr.violation) == 0
+
+
+def test_out_of_read(setup):
+    proj, simgr = setup(FILE_DIR/"out_of_read"/"enclave.so")
+    simgr.explore()
+
+    assert len(simgr.violation) == 0
+
+
+def test_out_of_write(setup):
+    proj, simgr = setup(FILE_DIR/"out_of_write"/"enclave.so")
+    simgr.explore()
+
+    assert len(simgr.violation) == 0
+
+
+def test_symbolic_jump(setup):
+    proj, simgr = setup(FILE_DIR/"symbolic_jump"/"enclave.so")
+    simgr.explore()
+
+    assert len(simgr.violation) == 0
+
+
+def test_symbolic_write(setup):
+    proj, simgr = setup(FILE_DIR/"symbolic_write"/"enclave.so")
+    simgr.explore()
+
+    assert len(simgr.violation) == 0
+
+
+def test_transition(setup):
+    proj = angr.Project(FILE_DIR/"transition"/"enclave.so")
+    ecalls = [
+        (ind, name, add, [(io[0][0], 0)])
+        for (ind, name, add, io) in guardian.tools.Heuristic.find_ecalls(proj)
+    ]
+    proj, simgr = setup(FILE_DIR/"transition"/"enclave.so", ecalls=ecalls)
+    simgr.explore()
+
+    assert len(simgr.violation) == 0
+
+
+def test_transition_two(setup):
+    proj, simgr = setup(FILE_DIR/"transition2"/"enclave.so", enter_addr=0x0)
+    simgr.explore()
+
+    assert len(simgr.violation) == 0


### PR DESCRIPTION
# Summary
Issue #3 . The last pull request #2 did not disable violation detection in `sim_procedures.py`. This Pull request fixes that.
I also added all test cased to make sure I didn't miss anything this time.

## Details
* A `violation_check` flag is handed down from `project.py` -> `hooker.py` -> `sim_procedures.py`
* Each `SimProcedure` now checks for `violation_check` before executing the check
* Non `violation check` Breakpoints reenabled
* Add angr options "SYMBOL_FILL_UNCONSTRAINED..." in Project.entry_state to silence Warnings, which improves angr logging output 

## Tests
### Test that original guardian Framework behaves normally
============================= test session starts ==============================
platform linux -- Python 3.9.15[pypy-7.3.10-final], pytest-7.2.1, pluggy-1.0.0
rootdir: [REDACTED]
collected 11 items

tests/test_violation_types.py ...........                                [100%]

============================= 11 passed in 32.00s ==============================
### Test that disabling violation check works 
============================= test session starts ==============================
platform linux -- Python 3.9.15[pypy-7.3.10-final], pytest-7.2.1, pluggy-1.0.0
rootdir: [REDACTED]
collected 11 items

test_disable_violation_check.py ...........                              [100%]

============================= 11 passed in 31.46s ==============================